### PR TITLE
Update .rubocop.yml

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -2,10 +2,15 @@ AllCops:
   Exclude:
     - '.*'
     - '**/spec/**/*'
+    - '**/coverage/**/*'
     - 'bin/**/*'
     - 'config/routes.rb'
-    - 'coverage/**/*'
     - 'db/**/*'
     - 'log/**/*'
     - 'org/**/*'
     - 'tmp/**/*'
+    - 'public/**/*'
+    - 'vendor/**/*'
+
+Metrics/LineLength:
+  Max: 110

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   Exclude:
     - '.*'
-    - '**/spec/**/*'
-    - '**/coverage/**/*'
+    - '**/spec/'
+    - '**/coverage/'
     - 'bin/**/*'
     - 'config/routes.rb'
     - 'db/**/*'


### PR DESCRIPTION
Update excludes and override Metrics/LineLength to max: 110