### PR TITLE
Disable Style/ModuleFunction

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'tmp/**/*'
     - 'public/**/*'
     - 'vendor/**/*'
+  DisplayCopNames: true
 
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
@@ -129,4 +130,7 @@ Style/SymbolArray:
   Enabled: false
 
 Style/WordArray:
+  Enabled: false
+  
+Style/ModuleFunction:
   Enabled: false


### PR DESCRIPTION
It forces you to use `module_function :a, :b, ...` at the bottom vs. `extend self` anywhere

Also enabled `DisplayCopNames`. It makes finding what the issue is easier (when using `rubocop` locally)