### PR TITLE
remove line length metric because it's annoying and antiquated

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -40,7 +40,13 @@ Metrics/CyclomaticComplexity:
   Max: 10
 
 Metrics/LineLength:
-  Enabled: false
+  Max: 120
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+  Exclude:
+    - '*/*/spec/**/*'
 
 Metrics/ModuleLength:
   Max: 100

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -36,11 +36,7 @@ Metrics/CyclomaticComplexity:
   Max: 10
 
 Metrics/LineLength:
-  Max: 135
-  AllowURI: true
-  URISchemes:
-  - http
-  - https
+  Enabled: false
 
 Metrics/ModuleLength:
   Max: 100


### PR DESCRIPTION
I wanted to put this up to a vote and make it easy as possible to execute should people agree with me.   Anyone in love with line length restrictions and want to keep it?