### PR TITLE
lint settings that we want to specialize for spec files

### DIFF
--- a/style/ruby/.spec_rubocop.yml
+++ b/style/ruby/.spec_rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from:
+  - ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false


### PR DESCRIPTION
Create a standard universal .rubocop.yml to apply to rspec scripts (rather than just ignoring them)

Projects are still able to independently configure how they want rubocop to interact with rspec via the .codeclimate.yml settings, but this allows us a company wide standard rubocop config that applies to rspec tests.  We want to start using this in qa-automations right away.

In order to use these configs, add something like this to .codeclimate.yml
```
prepare:
  fetch:
    - url: "https://raw.githubusercontent.com/BOA-Restrictor/guides/v0.3.0/style/ruby/.rubocop.yml"
      path: ".rubocop.yml"
    - url: "https://raw.githubusercontent.com/BOA-Restrictor/guides/v0.3.0/style/ruby/.spec_rubocop.yml"
      path: "spec/.rubocop.yml"
```